### PR TITLE
Update calculus.py mode and textposition

### DIFF
--- a/calculus.py
+++ b/calculus.py
@@ -43,7 +43,7 @@ def derivative_trace(list_of_terms, x_value, line_length = 4, delta = .01):
     trace = {'x': [x_minus, x_value, x_plus],
     'y': [y_minus, y, y_plus],
     'text': ['', "f' = " +  str(derivative_at), ''],
-    'mode': 'text+lines', 'textposition': 'bottom'}
+    'mode': 'text+lines', 'textposition': 'bottom center'}
     return trace
 
 def delta_traces(list_of_terms, x_value, line_length = 4, delta_x = .01):
@@ -54,11 +54,11 @@ def delta_traces(list_of_terms, x_value, line_length = 4, delta_x = .01):
 
 def function_values_trace(list_of_terms, x_values):
     function_values = list(map(lambda x: output_at(list_of_terms, x),x_values))
-    return trace_values(x_values, function_values, mode = 'line')
+    return trace_values(x_values, function_values, mode = 'lines')
 
 def derivative_values_trace(list_of_terms, x_values, delta_x):
     derivative_values = list(map(lambda x: derivative_of(list_of_terms, x, delta_x), x_values))
-    return trace_values(x_values, derivative_values, mode = 'line')
+    return trace_values(x_values, derivative_values, mode = 'lines')
 
 def function_and_derivative_trace(list_of_terms, x_values, delta_x):
     traced_function = function_values_trace(list_of_terms, x_values)


### PR DESCRIPTION
When running the code in the course it threw errors for mode and textposition properties, so I updated them to the correct values (e.g. 'lines' and 'bottom center').

<img width="773" alt="screen shot 2018-10-11 at 12 53 01 am" src="https://user-images.githubusercontent.com/26117677/46782838-cfca5e00-ccf5-11e8-8505-f08dc599962c.png">

<img width="722" alt="screen shot 2018-10-11 at 1 35 17 am" src="https://user-images.githubusercontent.com/26117677/46782882-fab4b200-ccf5-11e8-9be9-d56c6f3f656b.png">
